### PR TITLE
FolioReader | Fork | Removing version limit for realm pod

### DIFF
--- a/FolioReaderKit.podspec
+++ b/FolioReaderKit.podspec
@@ -35,6 +35,6 @@ Pod::Spec.new do |s|
   s.dependency 'ZFDragableModalTransition', '0.6'
   s.dependency 'AEXML', '4.3.3'
   s.dependency 'FontBlaster', '4.1.0'
-  s.dependency 'RealmSwift', '3.17.3'
+  s.dependency 'RealmSwift'
 
 end

--- a/Source/Models/Highlight+Helper.swift
+++ b/Source/Models/Highlight+Helper.swift
@@ -90,7 +90,7 @@ extension Highlight {
         do {
             let realm = try Realm(configuration: readerConfig.realmConfiguration)
             realm.beginWrite()
-            realm.add(self, update: true)
+            realm.add(self, update: .all)
             try realm.commitWrite()
             completion?(nil)
         } catch let error as NSError {


### PR DESCRIPTION
In order to run an up-to-date realm version I have to remove the limit version the pod had.